### PR TITLE
Fixed two broken links

### DIFF
--- a/Tecton_Quickstart.ipynb
+++ b/Tecton_Quickstart.ipynb
@@ -60,7 +60,9 @@
     "id": "ocOCkQN7uyNd"
    },
    "outputs": [],
-   "source": "!pip install 'tecton[rift]==1.2.0' gcsfs s3fs --force"
+   "source": [
+    "!pip install 'tecton[rift]==1.2.0' gcsfs s3fs --force"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -107,7 +109,7 @@
     "- A user's total transaction amount in the last 1 hour\n",
     "- A user's total transaction amount in the last 30 days\n",
     "\n",
-    "To do so, we will first define a [Stream Source](https://docs.tecton.ai/docs/defining-features/data-sources/creating-a-data-source/creating-and-testing-a-push-source) which tells Tecton where to retrieve events online and offline. For the online path, we've configured Tecton to accept real-time events via an HTTP ingestion API which we will try sending records to in the next step. For the offline path, we've pointed Tecton to an S3 path that contains a historical record of our stream. Tecton uses this path for offline development and backfills.\n",
+    "To do so, we will first define a [Stream Source](https://docs.tecton.ai/docs/defining-features/sources-data/data-sources/creating-a-data-source/creating-and-testing-a-push-source) which tells Tecton where to retrieve events online and offline. For the online path, we've configured Tecton to accept real-time events via an HTTP ingestion API which we will try sending records to in the next step. For the offline path, we've pointed Tecton to an S3 path that contains a historical record of our stream. Tecton uses this path for offline development and backfills.\n",
     "\n",
     "Next we define a [Stream Feature View](https://docs.tecton.ai/docs/defining-features/feature-views/stream-feature-view/stream-feature-view-with-rift) which can create one or more features via transformations against the Stream Source. In a Stream Feature View, we can run Python transformations on incoming records, and optionally apply time-windowed [aggregations](https://docs.tecton.ai/docs/defining-features/feature-types/aggregation-engine) via the `aggregations` parameter. These transformations run identically online and offline which is critical for preventing skew.\n",
     "\n",
@@ -172,7 +174,7 @@
    "source": [
     "The `_valid_to` and `valid_from` columns specify the time range for which the\n",
     "row of feature values is valid. See\n",
-    "[Offline Retrieval Methods](../reading-feature-data/reading-feature-data-for-training/offline-retrieval-methods)\n",
+    "[Offline Retrieval Methods](https://docs.tecton.ai/docs/reading-feature-data/reading-feature-data-for-training/offline-retrieval-methods)\n",
     "for more information.\n",
     "\n",
     "These results show us that our feature is working! For each user, we can see\n",


### PR DESCRIPTION
See https://linear.app/tecton/issue/DOCS-444/broken-docs-links-in-colab-notebooks for context